### PR TITLE
build(metadata): Remove -policy suffix from annotations

### DIFF
--- a/metadata.yml
+++ b/metadata.yml
@@ -48,12 +48,12 @@ executionMode: kubewarden-wapc
 backgroundAudit: true
 annotations:
   # artifacthub specific:
-  io.artifacthub.displayName: High Risk Service Account Policy
+  io.artifacthub.displayName: High Risk Service Account
   io.artifacthub.resources: Pod
   io.artifacthub.keywords: pod, security, serviceaccount
-  io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/high-risk-service-account-policy
+  io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/high-risk-service-account
   # kubewarden specific:
-  io.kubewarden.policy.title: high-risk-service-account-policy
+  io.kubewarden.policy.title: high-risk-service-account
   io.kubewarden.policy.version: 0.1.0
   io.kubewarden.policy.description: Policy to prevent the usage of serviceaccount with too many permissions
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>


### PR DESCRIPTION


## Description

The vast majority of our policies don't have the `-policy` suffix.
<!-- Please provide the link to the GitHub issue you are addressing -->


<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
CI expected to fail, needs kwctl supporting `can_i `capability.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
