### PR TITLE
feat(docs): docs about resource scope implication.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Workloads that use a high-privileged ServiceAccount are rejected.
 Every time a resource that uses a service account is submitted to the cluster,
 the policy will query the Kubernetes authorization API to check if the given
 ServiceAccount has some permissions that it shouldn't. To perform this
-verification, the policy will create an
+verification, the policy will create a
 [SubjectAccessReview](https://kubernetes.io/docs/reference/kubernetes-api/authorization-resources/subject-access-review-v1/)
 and apply it to check the service account permissions. If the result returned
 that the service account can perform such operation, the request is rejected.
@@ -33,17 +33,61 @@ Where the `namespace` is the namespace from the request and the
 `service-account` is the service account from the resource being deployed or
 the `default` one.
 
-The policy rejects a workload as soon as it found a blocked operation.
-Therefore, it avoids hitting the Kubernetes API too many times before rejecting
-the request.
+The policy rejects a workload as soon as it found a blocked operation to reduce
+the load on the Kubernetes API server.
 
-## Example
+## Settings
 
 The policy settings consist of a list of rules that service accounts are
 prohibited from having defined in any of their associated roles and cluster
-roles. The rules follow the same syntax as those defined in the
-[roles](https://kubernetes.io/docs/reference/kubernetes-api/authorization-resources/subject-access-review-v1/)
-specification.
+roles.
+
+```yaml
+blockRules:
+  # For listing secrets
+  - apiGroups: [""] # mandatory
+    resources: ["secrets"] # mandatory
+    verbs: ["list"] # mandatory
+    namespace: "default" # optional
+```
+
+The `apiGroups` and the `resources` fields are used to identify the Kubernetes
+resources to protect. The verbs list the operations that have to be prevented.
+
+The verbs field allow the following values: `create`, `update`, `delete`,
+`get`, `list`, `watch`, `proxy`, `*`, `patch` and `deletecollection`.
+
+### `namespace` Field Usage Guide
+
+The `namespace` attribute is optional. When specified, it defines the Namespace
+inside of which the operation has to be blocked. When not provided, the policy
+assumes the operation should be blocked at the cluster level.
+
+When protecting cluster-wide resources (e.g. `Node`, `ClusterRole`,
+`PersistentVolume`, `Namespace`), the namespace field must be omitted.
+
+When protecting a namespaced resource (e.g. `Secret`), you have to consider
+whether you want to prevent operation from being done inside of all the
+namespaces of the cluster or just some of them.
+
+> [!IMPORTANT]
+> Namespaced rules **never** implies cluster-wide access.
+> Rules without `namespace` checks **exclusively** for cluster-scoped permissions.
+>
+> Namespace-bound access (granted via Role + RoleBinding) and cluster-wide access
+> (via ClusterRole + ClusterRoleBinding) are mutually exclusive in authorization
+> checks. A service account with access to `Secrets` in its own namespace will
+> fail (`allowed: false`, which in this policy context means accepting the
+> resource in the cluster) a cluster-wide `SubjectAccessReview` check (e.g.,
+> listing Secrets across all namespaces). This occurs because Kubernetes enforces
+> strict scope isolation: permissions granted within a namespace never implicitly
+> extend to other namespaces or cluster-wide operations. `SubjectAccessReview`
+> precisely reflects this design. A cluster-wide check verifies global access
+> rights, while a namespace-scoped check validates local permissions.
+
+## Example
+
+Let's take a look in a example
 
 ```yaml
 blockRules:
@@ -77,9 +121,6 @@ blockRules:
     verbs: ["*"]
     namespace: "default"
 ```
-
-The verbs field allow the following values: `create`, `update`, `delete`,
-`get`, `list`, `watch`, `proxy`, `*`, `patch` and `deletecollection`.
 
 For example, if the policy is deployed with the previous configuration in a
 cluster that has a service account like this:
@@ -182,53 +223,8 @@ Error from server: error when creating "STDIN": admission webhook "clusterwide-h
 In the previous example, the user set in the `SubjectAccessReview` resource
 would be `system:serviceaccount:default:super-admin-sa`.
 
-## Resource Scope Implications for Authorization and Blocking Rules
-
-It's important to pay attention to the resources defined in `blockRules`
-settings. The scope of the resource (namespaces or cluster wide) can impact if
-a request will be blocked or not. For example, in the previous example, if the
-`super-admin-deployment` has the same permissions defined in a `Role` resource
-instead of `ClusterRole`, the deployment will be applied in the cluster. This
-is due the nature of how RBAC and authorization API works.
-
-Namespace-bound access (granted via Role + RoleBinding) and cluster-wide access
-(via ClusterRole + ClusterRoleBinding) are mutually exclusive in authorization
-checks. A service account with access to `Secrets` in its own namespace will
-fail (`allowed: false`, which in this policy context means accepting the
-resource in the cluster) a cluster-wide `SubjectAccessReview` check (e.g.,
-listing Secrets across all namespaces). This occurs because Kubernetes enforces
-strict scope isolation: permissions granted within a namespace never implicitly
-extend to other namespaces or cluster-wide operations. `SubjectAccessReview`
-precisely reflects this design. A cluster-wide check verifies global access
-rights, while a namespace-scoped check validates local permissions.
-
-Therefore, if you are blocking operations in namespaced resources. It's a good
-idea defining the namespaces field as well. Otherwise, the
-`SubjectAccessReview` will check if the user has permissions to perform this on
-**all** namespaces. Which is not true, because the `ServiceAccount` would have
-permissions to only a single namespace. Which will ended by allowing the
-resource in the cluster. In the other hand, if you are blocking a cluster-wide
-resource operation, the `namespace` field should be omitted.
-
-### `namespace` Field Usage Guide
-
-| **Scenario**                                                                            | **Use `namespace`?** | **Recommendation**                                                              | **Example**                                                     |
-| --------------------------------------------------------------------------------------- | -------------------- | ------------------------------------------------------------------------------- | --------------------------------------------------------------- |
-| **Namespace-scoped resources**<br>(Pod, Secret, Deployment) **in a specific namespace** | ✅ Yes               | Always set `namespace` to target the exact namespace.                           | `namespace: "dev"`                                              |
-| **Cluster-scoped resources**<br>(Node, ClusterRole, PersistentVolume)                   | ❌ No                | Omit `namespace` entirely.                                                      | Omit `namespace` + `resources: ["nodes"]`                       |
-| **Cluster-wide list/watch**<br>(e.g., list all Secrets)                                 | ❌ No                | Omit `namespace` to check cluster-wide permissions.                             | `verbs: ["list"]`, `resources: ["secrets"]`, **no namespace**   |
-| **Access to Namespace resources itself**<br>(e.g., delete a Namespace)                  | ❌ No                | Treat as cluster-scoped; omit `namespace`.                                      | `verbs: ["delete"]`, `resources: ["namespaces"]`                |
-| **Namespace-bound operation**<br>(e.g., create Pods in `prod`)                          | ✅ Yes               | Explicitly define `namespace` to restrict check to that namespace.              | `namespace: "prod"`, `verbs: ["create"]`, `resources: ["pods"]` |
-| **Checking cross-namespace access**<br>(e.g., can SA read Secrets in _any_ namespace?)  | ❌ No                | Omit `namespace` + use `verbs: "list"`/`"watch"` for cluster-wide verification. | `verbs: ["list"]`, `resources: ["secrets"]`, **no namespace**   |
-
-### Key Points:
-
-1. **Use `namespace` for:**
-   - Namespace-scoped resources **when targeting a specific namespace**.
-2. **Omit `namespace` for:**
-   - Cluster-scoped resources.
-   - Cluster-wide operations (`list`, `watch` across all namespaces).
-   - Actions on `Namespaces` themselves.
-3. **Critical Distinction:**
-   - Namespace-bound access **never** implies cluster-wide access.
-   - Rules without `namespace` checks **exclusively** for cluster-scoped permissions.
+As mentioned in the settings section, it's important to pay attention to if
+`blockRules` are performing namespaced or cluster wide checks. For example, in
+the previous example, if the `super-admin-deployment` has the same permissions
+defined in a `Role` resource instead of `ClusterRole`, the deployment will be
+applied in the cluster.


### PR DESCRIPTION
## Description

Adds a new documentation section explaning how the resource scope and the blockRules definition can impact in the final decision if a resource can by deployed in the cluster or not.

Fix #14 
